### PR TITLE
Server Sprites now face the direction they are walking to/fixed interaction bugs

### DIFF
--- a/Bennys/Assets/ArcadeGUI.cs
+++ b/Bennys/Assets/ArcadeGUI.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using System;
+using Bennys;
 
 public class ArcadeGUI : MonoBehaviour {
     public PlayerController player;
@@ -26,6 +27,13 @@ public class ArcadeGUI : MonoBehaviour {
         money = FindObjectOfType<PlayerMoney>();
         generate = GetComponent<GenerateMoney>();
 
+    }
+    private void Update()
+    {
+        if (PlayerManager.s.IsGrabbed)
+        {
+            gui.enabled = false;
+        }
     }
     //when the hide button is clicked, begin the hiding process
     public void OnClickPlay()

--- a/Bennys/Assets/Prefabs/Level Objects/Server.prefab
+++ b/Bennys/Assets/Prefabs/Level Objects/Server.prefab
@@ -45,6 +45,7 @@ GameObject:
   - component: {fileID: 114843846184039028}
   - component: {fileID: 65175486253112340}
   - component: {fileID: 114948147537200816}
+  - component: {fileID: 114907577144267314}
   m_Layer: 10
   m_Name: Server
   m_TagString: Npc
@@ -59,7 +60,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1383692921656544}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.56, y: -0.5, z: -2.28}
+  m_LocalPosition: {x: 8.71, y: -0.5, z: -0.45}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4310042692000260}
@@ -657,15 +658,27 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   points:
-  - {x: 1.5694578, y: 1, z: -2.791728}
-  - {x: 7.5340495, y: 1, z: -2.7909741}
-  - {x: 7.457015, y: 0, z: 2.0153413}
-  - {x: 1.5568738, y: 1, z: 1.9942468}
-  - {x: 1.6082189, y: 1, z: -2.7915666}
+  - {x: 8.76207, y: 1, z: -0.93423533}
+  - {x: 5.527879, y: 1, z: -0.9351572}
+  - {x: 5.5532455, y: 0, z: -4.0825043}
+  - {x: 8.7981825, y: 1, z: -4.090862}
+  - {x: 8.735392, y: 1, z: -0.9343674}
   IsCircular: 1
   pointSize: 0.25
   pointColor: {r: 1, g: 0, b: 0, a: 1}
   pathColor: {r: 1, g: 0, b: 0, a: 1}
+--- !u!114 &114907577144267314
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1383692921656544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e367772638c6dc240a88e889a88c8b1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sprite: {fileID: 212412400159237570}
 --- !u!114 &114948147537200816
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Bennys/Assets/ServerAnimationHandler.cs
+++ b/Bennys/Assets/ServerAnimationHandler.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Bennys;
+
+public class ServerAnimationHandler : MonoBehaviour {
+    LineOfSight line;
+    Animator animate;
+   public SpriteRenderer sprite;
+	// Use this for initialization
+	void Start () {
+        line = GetComponent<LineOfSight>();
+        animate = sprite.GetComponent<Animator>();
+	}
+	
+	// Update is called once per frame
+	void Update () {
+        animate.SetFloat("HorizontalMovement", line.Facing.x);
+        if(line.Facing.x > 0)
+        {
+            sprite.flipX = true;
+        }
+        else
+        {
+            sprite.flipX = false;
+        }
+	}
+}

--- a/Bennys/Assets/ServerAnimationHandler.cs.meta
+++ b/Bennys/Assets/ServerAnimationHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e367772638c6dc240a88e889a88c8b1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Bennys/Assets/TableGui.cs
+++ b/Bennys/Assets/TableGui.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using Bennys;
 
 public class TableGui : MonoBehaviour {
    public PlayerController player;
@@ -24,6 +25,14 @@ public class TableGui : MonoBehaviour {
         money = FindObjectOfType<PlayerMoney>();
         generate = GetComponent<GenerateMoney>();
        
+       
+    }
+    private void Update()
+    {
+        if (PlayerManager.s.IsGrabbed)
+        {
+            gui.enabled = false;
+        }
     }
     //when the hide button is clicked, begin the hiding process
     public void OnClickHide()

--- a/Bennys/Assets/TableInteraction.cs
+++ b/Bennys/Assets/TableInteraction.cs
@@ -14,6 +14,7 @@ namespace Bennys
         {
             player = PlayerManager.s.player.GetComponent<PlayerController>();
             playerinteract = PlayerManager.s.player.GetComponent<PlayerInteract>();
+            
 
             canvasObj.GetComponent<Canvas>().enabled = false;
             player.enabled = true;
@@ -22,9 +23,12 @@ namespace Bennys
         //OnInteraction main function for this object is to activate the menu for the player 
         public void OnInteraction()
         {
-            player.GetComponent<PlayerController>().enabled = false;
-            playerinteract.enabled = false;
-            canvasObj.GetComponent<Canvas>().enabled = true;
+            if (!PlayerManager.s.IsGrabbed)
+            {
+                player.GetComponent<PlayerController>().enabled = false;
+                playerinteract.enabled = false;
+                canvasObj.GetComponent<Canvas>().enabled = true;
+            }
         }
     }
 }


### PR DESCRIPTION
The sprite of each server flips towards the direction they are facing.
The player can no longer interact with furniture while they are caught